### PR TITLE
Add geoportal.sgb.gov.br support with checkbox automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ Repositório com scripts diversos
 UserScript unificado para automação de aceite de termos em sites de mineração:
 - **GEOANP**: Automatiza clique no botão "Prosseguir" do aviso LGPD
 - **SIGMINE (geo.anm.gov.br)**: Automatiza checkbox "Eu concordo" e botão "OK"
+- **Geoportal SGB**: Automatiza checkbox "Não mostrar esta tela de abertura novamente"
 
 📁 **Localização**: `/userscripts/Auto-Aceite LGPD e SIGMINE.user.js`  
 📖 **Documentação**: `/userscripts/README.md`
 
 #### Justificativa
-Ambos os domínios, https://geo.anm.gov.br/ e https://geomaps.anp.gov.br/, exigem, por algum motivo, que concordemos com os termos SEMPRE que atualizamos (refresh [f5]) ou acessamos ambas as páginas. Isso é deveras irritante! Ditante desse cenário, criei com auxílio de IA o script que vos apresento neste repositório.
+Os domínios https://geo.anm.gov.br/, https://geomaps.anp.gov.br/ e https://geoportal.sgb.gov.br/ exigem, por algum motivo, que concordemos com os termos SEMPRE que atualizamos (refresh [f5]) ou acessamos as páginas. Isso é deveras irritante! Diante desse cenário, criei com auxílio de IA o script que vos apresento neste repositório.
 
 #### Características:
 - ✅ Detecção automática de sites

--- a/userscripts/Auto-Aceite LGPD e SIGMINE.user.js
+++ b/userscripts/Auto-Aceite LGPD e SIGMINE.user.js
@@ -1,12 +1,13 @@
 // ==UserScript==
 // @name         Auto-Aceite LGPD e SIGMINE
 // @namespace    http://tampermonkey.net/
-// @version      0.1-beta
-// @description  Aceita automaticamente avisos de LGPD e termos no SIGMINE (ANM) e geoanp (ANP).
+// @version      0.2-beta
+// @description  Aceita automaticamente avisos de LGPD e termos no SIGMINE (ANM), geoanp (ANP) e geoportal (SGB).
 // @author       Nélis Júnior
 // @homepage     *://github.com/nelisjunior
 // @match        *://geo.anm.gov.br/*
 // @match        *://geomaps.anp.gov.br/geoanp/*
+// @match        *://geoportal.sgb.gov.br/*
 // @grant        none
 // ==/UserScript==
 
@@ -39,8 +40,15 @@
             return;
         }
 
+        // Caso geoportal - SGB
+        const geoportalCheckbox = document.querySelector('.confirmcheck-container [role="checkbox"]');
+        if (geoportalCheckbox && geoportalCheckbox.getAttribute('aria-checked') === 'false') {
+            geoportalCheckbox.click();
+            console.log('✅ Checkbox geoportal SGB clicada');
+        }
+
         // Mensagem de espera
-        if (!checkboxDiv && !lgpdBtn) {
+        if (!checkboxDiv && !lgpdBtn && !geoportalCheckbox) {
             console.log('⌛ Aguardando elementos aparecerem...');
         }
     }, 400);

--- a/userscripts/README.md
+++ b/userscripts/README.md
@@ -4,10 +4,11 @@
 
 > **📋 Pré-requisito**: É necessário ter o [TamperMonkey](https://www.tampermonkey.net/) instalado em seu navegador. Clique no botão acima para instalação automática do script.
 
-Este UserScript automatiza o processo de aceite de termos em dois sites relacionados à mineração no Brasil:
+Este UserScript automatiza o processo de aceite de termos em três sites relacionados à mineração no Brasil:
 
 - **GEOANP**: Automatiza o clique no botão "Prosseguir" do aviso LGPD
 - **SIGMINE (geo.anm.gov.br)**: Automatiza o checkbox "Eu concordo" e clique no botão "OK"
+- **Geoportal SGB**: Automatiza o checkbox "Não mostrar esta tela de abertura novamente"
 
 ## Funcionalidades
 
@@ -15,6 +16,7 @@ Este UserScript automatiza o processo de aceite de termos em dois sites relacion
 O script detecta automaticamente em qual site está executando:
 - Sites que contêm "geoanp" no hostname → Executa automação LGPD
 - Sites "geo.anm.gov.br" → Executa automação SIGMINE
+- Sites "geoportal.sgb.gov.br" → Executa automação Geoportal SGB
 
 ### 🤖 Automação GEOANP (LGPD)
 - Aguarda o aparecimento do botão "Prosseguir" do aviso LGPD
@@ -27,6 +29,12 @@ O script detecta automaticamente em qual site está executando:
 - Localiza e clica no botão "OK" 
 - Suporte a diferentes estruturas HTML (label associado, checkbox independente)
 - Fallback para busca por proximidade de texto
+
+### 🤖 Automação Geoportal SGB
+- Localiza checkbox com role="checkbox" dentro da .confirmcheck-container
+- Marca automaticamente quando aria-checked = 'false'
+- Aceita aviso "Não mostrar esta tela de abertura novamente"
+- Mantém compatibilidade com outros sites
 
 ### 🐛 Debug e Logging
 - Console logging detalhado para depuração
@@ -98,6 +106,13 @@ const DEBUG = true; // true para ativar, false para desativar
 ```
 
 ## Changelog
+
+### v0.2-beta
+- Adicionado suporte para geoportal.sgb.gov.br
+- Implementada automação para checkbox "Não mostrar esta tela de abertura novamente"
+- Seletor para checkbox com role="checkbox" dentro de .confirmcheck-container
+- Mantida compatibilidade com SIGMINE e GEOANP
+- Debug logging detalhado para o novo site
 
 ### v1.0.0
 - Implementação inicial

--- a/userscripts/test.html
+++ b/userscripts/test.html
@@ -15,6 +15,7 @@
     <div id="test-controls">
         <button onclick="simulateGeoANP()">Simular GEOANP</button>
         <button onclick="simulateSIGMINE()">Simular SIGMINE</button>
+        <button onclick="simulateGeoportal()">Simular Geoportal SGB</button>
         <button onclick="clearSimulation()">Limpar</button>
     </div>
     
@@ -24,7 +25,7 @@
         function simulateGeoANP() {
             // Simula o hostname do GEOANP
             Object.defineProperty(window.location, 'hostname', {
-                value: 'geoanp.gov.br',
+                value: 'geomaps.anp.gov.br',
                 writable: false
             });
             
@@ -32,7 +33,7 @@
                 <div class="lgpd-notice">
                     <h3>Aviso LGPD</h3>
                     <p>Este site utiliza cookies conforme a Lei Geral de Proteção de Dados.</p>
-                    <button id="lgpd-continue">Prosseguir</button>
+                    <button id="lgpd_compliance_agreed">Prosseguir</button>
                 </div>
             `;
             
@@ -49,15 +50,36 @@
             document.getElementById('simulation-area').innerHTML = `
                 <div class="sigmine-consent">
                     <h3>Termos de Uso</h3>
-                    <label>
-                        <input type="checkbox" id="agree-checkbox"> Eu concordo com os termos
-                    </label>
-                    <br><br>
-                    <button id="ok-button">OK</button>
+                    <div role="checkbox" aria-label="Eu concordo com os termos" aria-checked="false" style="cursor: pointer; border: 1px solid #ccc; padding: 5px; margin: 10px 0;">
+                        ☐ Eu concordo com os termos
+                    </div>
+                    <button title="OK" style="padding: 10px 20px;">OK</button>
                 </div>
             `;
             
             console.log('Simulação SIGMINE carregada');
+        }
+        
+        function simulateGeoportal() {
+            // Simula o hostname do Geoportal SGB
+            Object.defineProperty(window.location, 'hostname', {
+                value: 'geoportal.sgb.gov.br',
+                writable: false
+            });
+            
+            document.getElementById('simulation-area').innerHTML = `
+                <div class="geoportal-notice">
+                    <h3>Aviso de Abertura</h3>
+                    <p>Bem-vindo ao Geoportal SGB.</p>
+                    <div class="confirmcheck-container">
+                        <div role="checkbox" aria-checked="false" style="cursor: pointer; border: 1px solid #ccc; padding: 5px; margin: 10px 0;">
+                            ☐ Não mostrar esta tela de abertura novamente
+                        </div>
+                    </div>
+                </div>
+            `;
+            
+            console.log('Simulação Geoportal SGB carregada');
         }
         
         function clearSimulation() {


### PR DESCRIPTION
This pull request adds support for automating the acceptance of terms on the Geoportal SGB website to the existing UserScript, which previously handled automation for GEOANP and SIGMINE. The changes include updates to the script functionality, documentation, and test files to accommodate the new site.

### Feature Addition: Geoportal SGB Automation
* [`userscripts/Auto-Aceite LGPD e SIGMINE.user.js`](diffhunk://#diff-fa998b9127dd921742d34a38997c805deceb24d363dc68b064e27fdc2bc79d70R43-R51): Added functionality to locate and interact with the checkbox for "Não mostrar esta tela de abertura novamente" on Geoportal SGB, ensuring compatibility with existing sites.
* [`userscripts/README.md`](diffhunk://#diff-3091ff547fdf087c4d9b327458d851a6ab4f72b57da8b4c9651b7a886e9c0ee6L7-R19): Updated documentation to include Geoportal SGB as a supported site, detailing its automation process and adding a changelog entry for version `v0.2-beta`. [[1]](diffhunk://#diff-3091ff547fdf087c4d9b327458d851a6ab4f72b57da8b4c9651b7a886e9c0ee6L7-R19) [[2]](diffhunk://#diff-3091ff547fdf087c4d9b327458d851a6ab4f72b57da8b4c9651b7a886e9c0ee6R33-R38) [[3]](diffhunk://#diff-3091ff547fdf087c4d9b327458d851a6ab4f72b57da8b4c9651b7a886e9c0ee6R110-R116)

### Test Updates
* [`userscripts/test.html`](diffhunk://#diff-bda8420dc7dd8913d34eaaadc23feb06b40d46794e80ded4d257cbfde6b0b95dR18): Added simulation for Geoportal SGB, including a checkbox for "Não mostrar esta tela de abertura novamente" and logging for testing purposes. Updated existing simulations to improve accuracy. [[1]](diffhunk://#diff-bda8420dc7dd8913d34eaaadc23feb06b40d46794e80ded4d257cbfde6b0b95dR18) [[2]](diffhunk://#diff-bda8420dc7dd8913d34eaaadc23feb06b40d46794e80ded4d257cbfde6b0b95dL27-R36) [[3]](diffhunk://#diff-bda8420dc7dd8913d34eaaadc23feb06b40d46794e80ded4d257cbfde6b0b95dL52-R84)

### Minor Adjustments
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R21): Updated the description and justification to reflect the inclusion of Geoportal SGB.
* [`userscripts/Auto-Aceite LGPD e SIGMINE.user.js`](diffhunk://#diff-fa998b9127dd921742d34a38997c805deceb24d363dc68b064e27fdc2bc79d70L4-R10): Incremented version number to `0.2-beta` and updated the description to include Geoportal SGB.